### PR TITLE
feat: unify dataset schemas for instruction tuning

### DIFF
--- a/data/create_finetune_dataset.py
+++ b/data/create_finetune_dataset.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-"""Create a small fine-tune JSONL dataset from `initial_chess_q_and_a.md`.
-Each line will be a JSON object with a `text` field suitable for causal LM training:
-"Question: <q>\nAnswer: <a>".
+"""Create a small instruction-tuning JSONL dataset from
+`initial_chess_q_and_a.md`.
+
+Each line follows the `{task, prompt, response, meta}` schema, where ``task`` is
+set to ``"general_qa"`` and ``prompt`` contains the question followed by the
+`"Answer:"` tag.
 """
 import re
 import json
@@ -39,7 +42,12 @@ entries = entries[:limit]
 
 with OUT_FILE.open('w', encoding='utf-8') as f:
     for q, a in entries:
-        obj = {"text": f"Question: {q}\nAnswer: {a}"}
+        obj = {
+            "task": "general_qa",
+            "prompt": f"Question: {q}\nAnswer:",
+            "response": a,
+            "meta": {},
+        }
         f.write(json.dumps(obj, ensure_ascii=False) + "\n")
 
 print(f"Wrote {len(entries)} examples to {OUT_FILE}")

--- a/data/create_full_finetune_dataset.py
+++ b/data/create_full_finetune_dataset.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-"""Create a full fine-tune JSONL dataset from `data/processed/chess_conversations.json`.
-Handles several common schemas and writes lines of JSON with a `text` field suitable for causal LM
-training: "Question: <q>\nAnswer: <a>".
+"""Create a full instruction-tuning JSONL dataset from
+`data/processed/chess_conversations.json`.
+
+The script attempts to handle several common source schemas and writes lines in
+the `{task, prompt, response, meta}` format. The ``task`` field is set to
+``"general_qa"`` and ``prompt`` contains the question followed by ``"Answer:"``.
 
 Usage: python create_full_finetune_dataset.py [--max_examples N]
 """
@@ -181,8 +184,13 @@ if args.max_examples>0:
     examples = examples[:args.max_examples]
 
 with OUT_FILE.open('w', encoding='utf-8') as f:
-    for q,a in examples:
-        obj = {"text": f"Question: {q}\nAnswer: {a}"}
+    for q, a in examples:
+        obj = {
+            "task": "general_qa",
+            "prompt": f"Question: {q}\nAnswer:",
+            "response": a,
+            "meta": {},
+        }
         f.write(json.dumps(obj, ensure_ascii=False) + '\n')
 
 print(f"Wrote {len(examples)} examples to {OUT_FILE}")

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -135,7 +135,7 @@
   - [ ] PGN-derived next-move pairs: walk through games and emit (FEN → next move in UCI).
   - [ ] Puzzles first-move supervision: use the first move of the puzzle solution.
   - [ ] Stockfish-labeled random positions: sample diverse FENs and label best move at depth 8–12.
-  - [ ] Standardize JSONL schema: `{task, prompt, response, meta}` where:
+  - [x] Standardize JSONL schema: `{task, prompt, response, meta}` where:
     - `task`: `engine_uci` | `engine_pv` | `tutor_explain`
     - `prompt`: for engine `FEN: <fen>\nMove:`; for tutor `FEN: <fen>\nQuestion: <q>`
     - `response`: for engine exactly one UCI move (e.g., `e2e4`)
@@ -149,8 +149,8 @@
 
 - [ ] Switch to instruction-style label masking (predict only the answer):
   - [ ] Add `InstructionDataCollator` that masks prompt tokens (labels = -100) and keeps labels for response tokens only
-  - [ ] Update `train_lora_poc.py` to consume `{prompt, response, task}` and use the instruction collator
-  - [ ] Extend `dataset_mixer.py` to accept both `text` and `{prompt/response/task}` schemas without forcing a `text` field
+  - [x] Update `train_lora_poc.py` to consume `{prompt, response, task}` (instruction collator pending)
+  - [x] Extend `dataset_mixer.py` to accept both `text` and `{prompt/response/task}` schemas without forcing a `text` field
 - [ ] Curriculum emphasizing engine formatting first, then difficulty:
   - [ ] Phase A: easy UCI (openings, mates-in-1, simple captures) — 80–90% engine
   - [ ] Phase B: general middlegame FENs (SF-labeled) — 70% engine


### PR DESCRIPTION
## Summary
- support instruction and legacy text datasets in `dataset_mixer`
- emit `{task,prompt,response,meta}` records from dataset builders
- train script prefers prompt/response pairs when available
- project plan reflects dataset schema migration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_68c204b1e6288323b768e0e390882f91