### PR TITLE
chore: pin critical dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+### Updating dependency pins
+
+`requirements.txt` pins critical packages to versions compatible with Apple Silicon
+MPS (for example, `transformers==4.38.*` and `torch==2.2.*`). When dependencies
+change, regenerate the pinned list after installing the desired versions:
+
+```bash
+pip freeze > requirements.txt
+```
+
+This captures the exact versions in your environment and keeps the project
+reproducible.
+
 ### Basic Usage
 
 1. **Start web interface:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,28 @@
 # Dependencies for GemmaFischer - Chess LLM Engine + Tutor
 # Mac-only (M3 Pro) with MPS acceleration - no CUDA/CPU fallbacks
+#
+# When updating dependencies, install the desired versions and regenerate
+# pins with:
+#   pip freeze > requirements.txt
 
 # Core ML dependencies (MPS-optimized)
-transformers
+transformers==4.38.*
 datasets
 accelerate
 peft
 trl
 huggingface_hub
 unsloth  # Optimized for Apple Silicon MPS
-torch  # With MPS support for M3 Pro
-torchvision  # With MPS support
-torchaudio  # With MPS support
+torch==2.2.*  # With MPS support for M3 Pro
+torchvision==0.17.*  # With MPS support
+torchaudio==2.2.*  # With MPS support
 
 # Chess and UCI support
 python-chess
 stockfish  # Python wrapper for Stockfish engine
 
 # Web interface
-flask
+flask==3.0.*
 flask-cors
 
 # Data processing and embeddings (MPS-compatible)


### PR DESCRIPTION
## Summary
- pin torch, transformers, and flask to Apple Silicon-compatible version ranges
- document dependency pinning and regeneration with `pip freeze`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers'; OSError loading torch shared library)*

------
https://chatgpt.com/codex/tasks/task_e_68c48b7d5e98832385052e029d673044