### PR TITLE
Add deterministic seeding to LoRA training script

### DIFF
--- a/src/training/configs/lora_director_expert.yaml
+++ b/src/training/configs/lora_director_expert.yaml
@@ -10,6 +10,7 @@ training:
   fp16: false
   logging_steps: 50
   save_steps: 200
+  seed: 3407  # Random seed for reproducibility
   eval_strategy: "steps"
   eval_steps: 200
   save_strategy: "steps"

--- a/src/training/configs/lora_finetune.yaml
+++ b/src/training/configs/lora_finetune.yaml
@@ -11,6 +11,7 @@ training:
   fp16: false
   logging_steps: 10
   save_steps: 50
+  seed: 3407  # Random seed for reproducibility
 lora:
   r: 8
   lora_alpha: 16

--- a/src/training/configs/lora_tutor.yaml
+++ b/src/training/configs/lora_tutor.yaml
@@ -10,6 +10,7 @@ training:
   fp16: false
   logging_steps: 25
   save_steps: 100
+  seed: 3407  # Random seed for reproducibility
   eval_strategy: "steps"
   eval_steps: 100
   save_strategy: "steps"

--- a/src/training/configs/lora_uci.yaml
+++ b/src/training/configs/lora_uci.yaml
@@ -10,6 +10,7 @@ training:
   fp16: false
   logging_steps: 25  # More frequent logging
   save_steps: 100  # More frequent checkpoints
+  seed: 3407  # Random seed for reproducibility
   eval_strategy: "steps"
   eval_steps: 100
   save_strategy: "steps"

--- a/tests/test_seed_determinism.py
+++ b/tests/test_seed_determinism.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import torch
+from datasets import Dataset
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.training.train_lora_poc import set_seed
+
+
+def split_with_seed(seed: int):
+    set_seed(seed)
+    dataset = Dataset.from_dict({"x": list(range(10))})
+    split = dataset.train_test_split(test_size=0.3, seed=seed)
+    return split["train"]["x"], split["test"]["x"]
+
+
+def weights_with_seed(seed: int):
+    set_seed(seed)
+    model = torch.nn.Linear(5, 1)
+    return model.weight.detach().clone()
+
+
+def test_dataset_split_deterministic():
+    train1, test1 = split_with_seed(1234)
+    train2, test2 = split_with_seed(1234)
+    assert train1 == train2
+    assert test1 == test2
+
+
+def test_weight_init_deterministic():
+    w1 = weights_with_seed(4321)
+    w2 = weights_with_seed(4321)
+    assert torch.equal(w1, w2)


### PR DESCRIPTION
## Summary
- add `set_seed` utility seeding Python, NumPy and Torch RNGs
- apply seed from config or CLI to dataset mixing and train/test splits
- expose `seed` option in sample LoRA configs
- regression test confirms deterministic dataset splits and weight init

## Testing
- `pytest tests/test_seed_determinism.py -q`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'data')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b2c701ec8323b867ecf9459e4924