### PR TITLE
Fix UCI bridge isready handler and tests

### DIFF
--- a/src/inference/uci_bridge.py
+++ b/src/inference/uci_bridge.py
@@ -174,8 +174,13 @@ class UCIBridge:
     
     def _handle_isready(self) -> str:
         """Handle 'isready' command"""
-        if self.model_interface is None:
+        if self.inference is None:
+            logger.debug("Inference not initialized; responding with readyok")
             return "readyok"
+
+        if not getattr(self.inference, "is_loaded", False):
+            logger.debug("Inference not yet loaded; responding with readyok")
+
         return "readyok"
     
     def _handle_setoption(self, args: List[str]) -> str:

--- a/tests/test_uci_bridge.py
+++ b/tests/test_uci_bridge.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for the UCIBridge command handlers."""
+
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Provide lightweight stand-ins for optional heavy dependencies before importing the bridge
+peft_stub = types.ModuleType("peft")
+peft_stub.PeftModel = object  # Minimal placeholder used only for type references
+peft_stub.__spec__ = importlib.machinery.ModuleSpec("peft", loader=None)
+sys.modules["peft"] = peft_stub
+
+# Ensure project root is on sys.path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.inference.uci_bridge import UCIBridge
+
+
+@pytest.mark.parametrize("inference_behavior", ["missing", "unloaded"])
+def test_handle_isready_returns_readyok(inference_behavior):
+    """`isready` should always respond with readyok without raising."""
+    with patch("src.inference.uci_bridge.ChessEngineManager"):
+        if inference_behavior == "missing":
+            with patch(
+                "src.inference.uci_bridge.ChessGemmaInference",
+                side_effect=RuntimeError("inference init failed"),
+            ):
+                bridge = UCIBridge()
+                response = bridge.handle_uci_command("isready")
+                assert bridge.inference is None
+        else:
+            mock_inference = Mock()
+            mock_inference.is_loaded = False
+            with patch(
+                "src.inference.uci_bridge.ChessGemmaInference", return_value=mock_inference
+            ):
+                bridge = UCIBridge()
+                response = bridge.handle_uci_command("isready")
+                assert bridge.inference is mock_inference
+
+    assert response == "readyok"


### PR DESCRIPTION
## Summary
- update the UCI bridge `isready` handler to rely on the existing inference attribute and always respond with `readyok`
- add coverage to ensure the handler tolerates missing or unloaded inference instances without throwing

## Testing
- pytest tests/test_uci_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcd6f93e483238e01a48c882e9d86