### PR TITLE
Route UCI bridge engine requests through engine mode

### DIFF
--- a/src/inference/uci_bridge.py
+++ b/src/inference/uci_bridge.py
@@ -88,6 +88,11 @@ class UCIBridge:
         self.engine_name = "ChessGemma"
         self.author = "ChessGemma Team"
         self.version = "2.0.0"
+        self._last_generation_metadata: Dict[str, Optional[str]] = {
+            "requested_mode": None,
+            "routed_mode": None,
+            "generation_mode": None,
+        }
 
         # Initialize inference with MoE support
         try:
@@ -342,6 +347,11 @@ class UCIBridge:
     def _generate_chessgemmma_move(self, board: chess.Board, depth: int, time_limit: int) -> Optional[str]:
         """Generate a move using ChessGemma with enhanced UCI validation and post-processing"""
         if self.inference is None:
+            self._last_generation_metadata = {
+                "requested_mode": self.options.mode,
+                "routed_mode": None,
+                "generation_mode": None,
+            }
             return None
 
         try:
@@ -349,21 +359,28 @@ class UCIBridge:
             fen = board.fen()
 
             # Determine expert mode based on UCI options
-            expert_mode = self.options.mode
-            if expert_mode == "auto":
-                # Use MoE auto-routing if enabled
-                expert_mode = "auto" if self.options.moe_enabled else "uci"
+            requested_mode = self.options.mode
+            routed_mode = requested_mode
+            if routed_mode == "auto" and not self.options.moe_enabled:
+                routed_mode = "uci"
+
+            generation_mode = "engine" if routed_mode in ("uci", "auto") else routed_mode
+            self._last_generation_metadata = {
+                "requested_mode": requested_mode,
+                "routed_mode": routed_mode,
+                "generation_mode": generation_mode,
+            }
 
             # Create prompt based on mode using enhanced prompt functions
-            if expert_mode == "tutor":
+            if routed_mode == "tutor":
                 prompt = create_tutor_prompt_with_uci(fen, "Analyze this position step by step")
             else:
                 prompt = create_engine_prompt_strict(fen)
 
             # Generate response using ChessGemma
             response_dict = self.inference.generate_response(
-                prompt, 
-                mode=expert_mode,
+                prompt,
+                mode=generation_mode,
                 max_new_tokens=8,  # Limit for UCI moves
                 temperature=0.0,   # Deterministic for engine mode
                 top_p=1.0

--- a/tests/test_uci_bridge_modes.py
+++ b/tests/test_uci_bridge_modes.py
@@ -1,0 +1,103 @@
+"""Tests for UCIBridge mode routing logic."""
+
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import chess
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Provide lightweight stub for optional peft dependency used during imports
+peft_stub = types.ModuleType("peft")
+peft_stub.__spec__ = importlib.machinery.ModuleSpec("peft", loader=None)
+
+
+class _DummyPeftModel:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):  # pragma: no cover - simple stub
+        return None
+
+
+peft_stub.PeftModel = _DummyPeftModel
+sys.modules.setdefault("peft", peft_stub)
+
+from src.inference.uci_bridge import UCIBridge
+
+
+def _setup_bridge(mock_inference_cls, mock_engine_manager):
+    mock_inference = Mock()
+    mock_inference.generate_response.return_value = {"response": "e2e4"}
+    mock_inference_cls.return_value = mock_inference
+    mock_engine_manager.return_value = Mock()
+
+    bridge = UCIBridge()
+    return bridge, mock_inference
+
+
+@patch("src.inference.uci_bridge.ChessEngineManager")
+@patch("src.inference.uci_bridge.ChessGemmaInference")
+def test_uci_mode_uses_engine_generation(mock_inference_cls, mock_engine_manager):
+    bridge, mock_inference = _setup_bridge(mock_inference_cls, mock_engine_manager)
+    bridge.options.mode = "uci"
+
+    board = chess.Board()
+
+    with patch("src.inference.uci_bridge.post_process_uci_response", return_value="e2e4"):
+        move = bridge._generate_chessgemmma_move(board, depth=12, time_limit=1000)
+
+    assert move == "e2e4"
+    _, kwargs = mock_inference.generate_response.call_args
+    assert kwargs["mode"] == "engine"
+    assert bridge._last_generation_metadata == {
+        "requested_mode": "uci",
+        "routed_mode": "uci",
+        "generation_mode": "engine",
+    }
+
+
+@patch("src.inference.uci_bridge.ChessEngineManager")
+@patch("src.inference.uci_bridge.ChessGemmaInference")
+def test_auto_mode_routes_to_engine_and_records_request(mock_inference_cls, mock_engine_manager):
+    bridge, mock_inference = _setup_bridge(mock_inference_cls, mock_engine_manager)
+    bridge.options.mode = "auto"
+    bridge.options.moe_enabled = True
+
+    board = chess.Board()
+
+    with patch("src.inference.uci_bridge.post_process_uci_response", return_value="e2e4"):
+        move = bridge._generate_chessgemmma_move(board, depth=12, time_limit=1000)
+
+    assert move == "e2e4"
+    _, kwargs = mock_inference.generate_response.call_args
+    assert kwargs["mode"] == "engine"
+    assert bridge._last_generation_metadata == {
+        "requested_mode": "auto",
+        "routed_mode": "auto",
+        "generation_mode": "engine",
+    }
+
+
+@patch("src.inference.uci_bridge.ChessEngineManager")
+@patch("src.inference.uci_bridge.ChessGemmaInference")
+def test_auto_mode_without_moe_behaves_like_uci(mock_inference_cls, mock_engine_manager):
+    bridge, mock_inference = _setup_bridge(mock_inference_cls, mock_engine_manager)
+    bridge.options.mode = "auto"
+    bridge.options.moe_enabled = False
+
+    board = chess.Board()
+
+    with patch("src.inference.uci_bridge.post_process_uci_response", return_value="e2e4"):
+        move = bridge._generate_chessgemmma_move(board, depth=12, time_limit=1000)
+
+    assert move == "e2e4"
+    _, kwargs = mock_inference.generate_response.call_args
+    assert kwargs["mode"] == "engine"
+    assert bridge._last_generation_metadata == {
+        "requested_mode": "auto",
+        "routed_mode": "uci",
+        "generation_mode": "engine",
+    }


### PR DESCRIPTION
## Summary
- update the UCI bridge to normalize `auto`/`uci` requests to the deterministic engine generation mode while tracking requested, routed, and generation metadata
- keep tutor/director behavior intact and store metadata when inference is unavailable for downstream inspection
- add unit tests that mock inference to ensure `auto` and `uci` requests invoke the engine mode and record the expected metadata

## Testing
- pytest tests/test_uci_bridge_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcd70ad208323a1338581874c44f1