### PR TITLE
Align MoE UCI routing with engine mode

### DIFF
--- a/src/inference/inference.py
+++ b/src/inference/inference.py
@@ -184,6 +184,7 @@ class ChessGemmaInference:
         self.moe_manager: Optional[MoEInferenceManager] = None
         self.moe_enabled = MOE_AVAILABLE and (os.environ.get('CHESSGEMMA_MOE_ENABLED', '1') not in ('0', 'false', 'False'))
         self._expert_paths: Dict[str, str] = {}
+        self._moe_dispatch_depth = 0
 
         # Initialize MoE if available and enabled
         if self.moe_enabled and MOE_AVAILABLE:
@@ -478,6 +479,10 @@ class ChessGemmaInference:
             start_time = time.time()
             self._total_requests += 1
 
+            requested_mode = mode
+            if mode == "uci":
+                mode = "engine"
+
             if not self.is_loaded:
                 return {
                     "error": "Model not loaded",
@@ -485,7 +490,9 @@ class ChessGemmaInference:
                     "confidence": 0.0,
                     "model_loaded": False,
                     "generation_time": time.time() - start_time,
-                    "cached": False
+                    "cached": False,
+                    "mode": mode,
+                    "requested_mode": requested_mode,
                 }
 
             # Apply expert-specific decoding parameters
@@ -497,10 +504,17 @@ class ChessGemmaInference:
             if cached_response:
                 cached_response["cached"] = True
                 cached_response["cache_hit_rate"] = self._cache_hits / self._total_requests
+                if requested_mode != mode:
+                    cached_response.setdefault("requested_mode", requested_mode)
                 return cached_response
 
             # Use MoE routing if available and enabled
-            if self.moe_enabled and self.moe_manager and mode in ['tutor', 'engine', 'director']:
+            if (
+                self.moe_enabled
+                and self.moe_manager
+                and self._moe_dispatch_depth == 0
+                and mode in ['tutor', 'engine', 'director']
+            ):
                 try:
                     # Extract FEN for MoE routing
                     from .uci_utils import extract_fen
@@ -522,7 +536,7 @@ class ChessGemmaInference:
 
                         # Add MoE metadata to response
                         moe_info = moe_result.get('routing_info', {})
-                        return {
+                        payload = {
                             "response": response,
                             "confidence": moe_info.get('confidence_score', 0.5),
                             "model_loaded": True,
@@ -533,6 +547,9 @@ class ChessGemmaInference:
                             "routing_reasoning": moe_info.get('reasoning'),
                             "expert_weights": moe_info.get('expert_weights', {}),
                         }
+                        if requested_mode != mode:
+                            payload["requested_mode"] = requested_mode
+                        return payload
                 except Exception as e:
                     logger.info(f"MoE routing failed, falling back to standard inference: {e}")
                     # Fall through to standard inference
@@ -715,6 +732,9 @@ class ChessGemmaInference:
                 "tokens_per_second": len(answer.split()) / max(generation_time, 0.001)
             }
 
+            if requested_mode != mode:
+                response_dict["requested_mode"] = requested_mode
+
             # Cache the response for future use
             self._cache_response(cache_key, response_dict)
 
@@ -727,6 +747,7 @@ class ChessGemmaInference:
                 "confidence": 0.0,
                 "model_loaded": True,
                 "mode": mode,
+                "requested_mode": requested_mode,
                 "generation_time": generation_time,
                 "cached": False,
                 "cache_hit_rate": self._generation_stats['cache_hit_rate']
@@ -768,7 +789,8 @@ class ChessGemmaInference:
         }
         
         # Get expert defaults
-        expert_defaults = expert_params.get(mode, expert_params["tutor"])
+        normalized_mode = "engine" if mode == "uci" else mode
+        expert_defaults = expert_params.get(normalized_mode, expert_params["tutor"])
         
         # Use provided values or expert defaults
         final_temperature = temperature if temperature is not None else expert_defaults["temperature"]

--- a/src/inference/moe_router.py
+++ b/src/inference/moe_router.py
@@ -669,12 +669,24 @@ class MoEInferenceManager:
                 else:  # director
                     question = f"FEN: {fen}\nAnalyze this chess position strategically."
 
-                # Get response from the actual inference system
-                result = self.inference_system.generate_response(
-                    question,
-                    context=f"Current position: {fen}",
-                    mode=expert_name
-                )
+                inference_mode = 'engine' if expert_name == 'uci' else expert_name
+
+                # Prevent recursive MoE dispatch when delegating back to inference
+                depth_attr = '_moe_dispatch_depth'
+                previous_depth = getattr(self.inference_system, depth_attr, None)
+                if previous_depth is not None:
+                    setattr(self.inference_system, depth_attr, previous_depth + 1)
+
+                try:
+                    # Get response from the actual inference system
+                    result = self.inference_system.generate_response(
+                        question,
+                        context=f"Current position: {fen}",
+                        mode=inference_mode
+                    )
+                finally:
+                    if previous_depth is not None:
+                        setattr(self.inference_system, depth_attr, previous_depth)
 
                 return {
                     'response': result.get('response', f'Analysis from {expert_name} expert'),

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6,12 +6,30 @@ Comprehensive tests for ChessGemma inference functionality.
 import pytest
 import sys
 import logging
+import types
+import importlib.machinery
 from pathlib import Path
 from unittest.mock import Mock, patch
+
+import chess
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
+
+# Provide lightweight stub for optional peft dependency used during imports
+peft_stub = types.ModuleType("peft")
+peft_stub.__spec__ = importlib.machinery.ModuleSpec("peft", loader=None)
+
+
+class _DummyPeftModel:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):  # pragma: no cover - simple stub
+        return None
+
+
+peft_stub.PeftModel = _DummyPeftModel
+sys.modules.setdefault("peft", peft_stub)
 
 from src.inference.inference import (
     ChessGemmaInference,
@@ -20,6 +38,7 @@ from src.inference.inference import (
     unload_model,
     get_model_info,
 )
+from src.inference.moe_router import RoutingDecision, MoEInferenceManager
 
 
 class TestChessGemmaInference:
@@ -155,10 +174,82 @@ class TestChessGemmaInference:
         """Test response generation when model not loaded."""
         inference = ChessGemmaInference()
         result = inference.generate_response("Test question")
-        
+
         assert "error" in result
         assert result["confidence"] == 0.0
-    
+
+    def test_moe_uci_route_produces_legal_move(self, monkeypatch):
+        """MoE routing to the UCI expert should yield a legal engine move."""
+
+        # Disable automatic MoE initialization so the test can inject a stub manager
+        monkeypatch.setenv('CHESSGEMMA_MOE_ENABLED', '0')
+
+        inference = ChessGemmaInference()
+        inference.is_loaded = True
+
+        # Provide lightweight model/tokenizer stubs for engine generation
+        class _DummyTensor:
+            shape = (1, 1)
+
+        class _DummyInputs(dict):
+            def __init__(self):
+                super().__init__({'input_ids': _DummyTensor()})
+
+            def to(self, device):
+                return self
+
+        class _DummyTokenizer:
+            eos_token_id = 0
+
+            def __call__(self, *args, **kwargs):  # pragma: no cover - simple stub
+                return _DummyInputs()
+
+        inference.tokenizer = _DummyTokenizer()
+        mock_model = Mock()
+        mock_model.device = 'cpu'
+        inference.model = mock_model
+        inference.set_active_adapter = Mock()
+
+        # Force the engine helper to return a deterministic move
+        inference._generate_engine_move = Mock(return_value='e2e4')
+
+        class _StubRouter:
+            def __init__(self):
+                self.last_query_type = None
+
+            def route_query(self, fen, query_type="auto", complexity_score=None):
+                self.last_query_type = query_type
+                return RoutingDecision(
+                    primary_expert='uci',
+                    expert_weights={'uci': 1.0},
+                    confidence_score=0.9,
+                    reasoning='test route',
+                    ensemble_mode=False,
+                    fallback_used=False,
+                )
+
+        router = _StubRouter()
+        moe_manager = MoEInferenceManager(router, {}, inference)
+        inference.moe_manager = moe_manager
+        inference.moe_enabled = True
+
+        starting_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        question = f"FEN: {starting_fen}"
+
+        with patch('src.inference.uci_utils.extract_first_legal_move_uci', return_value='e2e4') as mock_extract:
+            result = inference.generate_response(question, mode='engine')
+
+        inference._generate_engine_move.assert_called_once()
+        mock_extract.assert_called()
+        assert result["moe_used"] is True
+        move_str = result["response"]
+        assert len(move_str) in (4, 5)
+
+        board = chess.Board(starting_fen)
+        move = chess.Move.from_uci(move_str)
+        assert move in board.legal_moves
+        assert router.last_query_type == 'engine'
+
     def test_get_model_info(self):
         """Test model info retrieval."""
         inference = ChessGemmaInference()


### PR DESCRIPTION
## Summary
- normalize UCI requests to the engine pathway so MoE routing reuses constrained decoding and records the caller's requested mode
- invoke engine-mode inference for MoE UCI experts while guarding against recursive MoE dispatch
- add a regression test that exercises the MoE UCI route end-to-end with lightweight stubs and verifies the produced move is legal

## Testing
- pytest tests/test_inference.py


------
https://chatgpt.com/codex/tasks/task_e_68cdda549f908323bf5a0bfe1b94c1be