### PR TITLE
Improve MoE initialization and priming

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ ChessGemma/
 └── docs/             # Documentation
 ```
 
+## MoE Checkpoint Layout
+
+The MoE inference stack expects checkpoints to be organized relative to the
+project root:
+
+- `checkpoints/lora_full/checkpoint-*/` – UCI expert adapter snapshots.
+- `checkpoints/lora_tutor/checkpoint-*/` – Tutor expert adapter snapshots.
+- `checkpoints/lora_director/checkpoint-*/` – Director expert adapter snapshots.
+- `checkpoints/moe_router/` – Router weights (for example `router.pt` or
+  `checkpoint-*/router.pt`).
+
+Set the `CHESSGEMMA_MOE_ROUTER_CKPT` environment variable to point at a custom
+router file if it lives outside the default directory. When any of the expected
+checkpoints are missing the system automatically falls back to single-expert
+mode with detailed logging.
+
 ## Architecture Overview
 
 - **Mixture of Experts (MoE)**: Intelligent routing between UCI, Tutor, and Director experts

--- a/src/inference/inference.py
+++ b/src/inference/inference.py
@@ -93,6 +93,20 @@ def _find_latest_dir(patterns: List[str]) -> Optional[Path]:
     return candidates[0]
 
 
+def _find_latest_file(patterns: List[str]) -> Optional[Path]:
+    """Find the most recently modified file matching any of the glob patterns."""
+    candidates: List[Path] = []
+    for pattern in patterns:
+        for path in glob.glob(pattern):
+            p = Path(path)
+            if p.is_file():
+                candidates.append(p)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
 def _resolve_default_model_path(project_root: Path) -> Optional[Path]:
     """Resolve the local base model snapshot directory under models/."""
     base = project_root / "models" / "unsloth-gemma-3-270m-it" / "models--unsloth--gemma-3-270m-it" / "snapshots"
@@ -190,30 +204,121 @@ class ChessGemmaInference:
             self._initialize_moe_system()
 
     def _initialize_moe_system(self) -> None:
-        """Initialize the Mixture of Experts system."""
+        """Initialize the Mixture of Experts system.
+
+        Router checkpoints are expected under ``checkpoints/moe_router/`` and
+        expert adapters under ``checkpoints/lora_<expert>/checkpoint-*/``.
+        """
+
+        def _disable_moe(message: str, level: str = "warning") -> None:
+            log_fn = getattr(logger, level, logger.warning)
+            log_fn(message)
+            self.moe_enabled = False
+            self.moe_router = None
+            self.moe_manager = None
+
         try:
-            # Set up expert paths for MoE
             checkpoints_root = self.project_root / "checkpoints"
-            self._expert_paths = {
-                'uci': str(_find_latest_dir([str(checkpoints_root / "lora_full" / "checkpoint-*")])),  # Use full model for UCI
-                'tutor': str(_find_latest_dir([str(checkpoints_root / "lora_tutor" / "checkpoint-*")])),
-                'director': str(_find_latest_dir([str(checkpoints_root / "lora_director" / "checkpoint-*")]))
+            if not checkpoints_root.exists():
+                _disable_moe(
+                    f"MoE checkpoints directory not found at {checkpoints_root}. "
+                    "Falling back to single-expert mode.",
+                    level="info",
+                )
+                return
+
+            expert_search_patterns = {
+                "uci": [str(checkpoints_root / "lora_full" / "checkpoint-*")],
+                "tutor": [str(checkpoints_root / "lora_tutor" / "checkpoint-*")],
+                "director": [str(checkpoints_root / "lora_director" / "checkpoint-*")],
             }
 
-            # Filter out None values
-            self._expert_paths = {k: v for k, v in self._expert_paths.items() if v is not None}
+            expert_paths: Dict[str, str] = {}
+            for expert, patterns in expert_search_patterns.items():
+                latest_dir = _find_latest_dir(patterns)
+                if latest_dir is not None:
+                    expert_paths[expert] = str(latest_dir)
+                    logger.debug(
+                        "Discovered %s expert adapter at %s", expert, latest_dir
+                    )
+                else:
+                    logger.info(
+                        "No adapter checkpoint found for %s expert (searched %s)",
+                        expert,
+                        patterns,
+                    )
 
-            if len(self._expert_paths) >= 2:  # Need at least 2 experts for MoE
-                self.moe_router = ChessMoERouter(num_experts=len(self._expert_paths))
-                self.moe_manager = MoEInferenceManager(self.moe_router, self._expert_paths, self)
-                print(f"🧠 MoE System initialized with {len(self._expert_paths)} experts: {list(self._expert_paths.keys())}")
-            else:
-                print("⚠️  Insufficient expert checkpoints for MoE (need at least 2), falling back to single-expert mode")
-                self.moe_enabled = False
+            self._expert_paths = expert_paths
+
+            if len(self._expert_paths) < 2:
+                _disable_moe(
+                    "Insufficient expert checkpoints for MoE (need at least 2). "
+                    "Falling back to single-expert mode.",
+                    level="info",
+                )
+                return
+
+            router_override = os.environ.get("CHESSGEMMA_MOE_ROUTER_CKPT")
+            router_checkpoint: Optional[Path] = None
+            if router_override:
+                candidate = Path(router_override).expanduser()
+                if candidate.is_file():
+                    router_checkpoint = candidate
+                    logger.info(
+                        "Using MoE router checkpoint override from %s", candidate
+                    )
+                else:
+                    logger.warning(
+                        "MoE router checkpoint override %s not found; falling back to default search",
+                        router_override,
+                    )
+
+            if router_checkpoint is None:
+                router_dir = checkpoints_root / "moe_router"
+                router_patterns = [
+                    str(router_dir / "router*.pt"),
+                    str(router_dir / "router*.bin"),
+                    str(router_dir / "router*.safetensors"),
+                    str(router_dir / "checkpoint-*" / "router*.pt"),
+                    str(router_dir / "checkpoint-*" / "*.pt"),
+                    str(router_dir / "checkpoint-*" / "*.bin"),
+                    str(router_dir / "checkpoint-*" / "*.safetensors"),
+                    str(router_dir / "*.pt"),
+                    str(router_dir / "*.bin"),
+                    str(router_dir / "*.safetensors"),
+                ]
+                router_checkpoint = _find_latest_file(router_patterns)
+
+            if router_checkpoint is None:
+                _disable_moe(
+                    "MoE router checkpoint not found (expected under checkpoints/moe_router/). "
+                    "Falling back to single-expert mode.",
+                    level="info",
+                )
+                return
+
+            self.moe_router = ChessMoERouter(num_experts=len(self._expert_paths))
+            try:
+                self.moe_router.load_router(str(router_checkpoint))
+            except Exception as exc:
+                _disable_moe(
+                    f"Failed to load MoE router checkpoint at {router_checkpoint}: {exc}",
+                    level="error",
+                )
+                return
+
+            self.moe_manager = MoEInferenceManager(
+                self.moe_router, self._expert_paths, self
+            )
+            logger.info(
+                "MoE System initialized with experts: %s", list(self._expert_paths.keys())
+            )
 
         except Exception as e:
-            print(f"⚠️  Failed to initialize MoE system: {e}")
-            self.moe_enabled = False
+            _disable_moe(
+                f"Unexpected error while initializing MoE system: {e}",
+                level="error",
+            )
 
     def load_model(self) -> bool:
         """Lazily load tokenizer and model (MPS/Auto device)."""
@@ -264,6 +369,11 @@ class ChessGemmaInference:
                     print(f"⚠️  Model validation error: {val_e}")
 
             self.is_loaded = True
+            if self.moe_enabled and self.moe_manager:
+                try:
+                    self.moe_manager.prime_available_experts()
+                except Exception as moe_err:
+                    logger.warning("MoE expert priming failed: %s", moe_err)
             return True
         except Exception as e:
             print(f"❌ Error loading model: {e}")

--- a/src/inference/moe_router.py
+++ b/src/inference/moe_router.py
@@ -19,7 +19,7 @@ Features:
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Dict, List, Any, Optional, Tuple, Union
+from typing import Dict, List, Any, Optional, Tuple, Union, Set
 import numpy as np
 import logging
 from pathlib import Path
@@ -618,14 +618,103 @@ class MoEInferenceManager:
         self.expert_models = expert_models
         self.inference_system = inference_system
         self.metrics = MoERoutingMetrics()
+        self._expert_adapter_paths: Dict[str, Path] = {}
+        self._expert_ready: Dict[str, bool] = {}
+        self._missing_expert_logged: Set[str] = set()
+        self._priming_lock = threading.Lock()
+        self._deferred_prime_logged = False
 
-        # Load expert models
+        if self.inference_system and hasattr(self.inference_system, "refresh_adapters"):
+            try:
+                self.inference_system.refresh_adapters()
+            except Exception as refresh_err:
+                logger.warning(
+                    "Unable to refresh adapters during MoE initialization: %s",
+                    refresh_err,
+                )
+
         for expert_name, model_path in expert_models.items():
-            if Path(model_path).exists():
-                logger.info(f"Loading {expert_name} expert from {model_path}")
-                # Load logic would go here
+            path_obj = Path(model_path) if model_path else None
+            if path_obj and path_obj.exists():
+                self._expert_adapter_paths[expert_name] = path_obj
+                self._expert_ready[expert_name] = False
+                logger.info("Registered %s expert adapter at %s", expert_name, path_obj)
             else:
-                logger.warning(f"Expert model not found: {model_path}")
+                logger.warning(
+                    "Expert model not found for %s: %s", expert_name, model_path
+                )
+
+        self.prime_available_experts()
+
+    def prime_available_experts(self) -> None:
+        """Ensure all known experts are loaded into the shared inference model."""
+        if not self.inference_system or not hasattr(
+            self.inference_system, "set_active_adapter"
+        ):
+            logger.debug("No inference system available to prime MoE experts")
+            return
+
+        if not getattr(self.inference_system, "is_loaded", False):
+            if not self._deferred_prime_logged:
+                logger.info(
+                    "MoE expert priming deferred until base model weights are loaded"
+                )
+                self._deferred_prime_logged = True
+            return
+
+        with self._priming_lock:
+            self._deferred_prime_logged = False
+            for expert_name in list(self._expert_adapter_paths.keys()):
+                self._prime_single_expert(expert_name)
+
+    def _prime_single_expert(self, expert_name: str) -> None:
+        if self._expert_ready.get(expert_name):
+            return
+
+        adapter_path = self._expert_adapter_paths.get(expert_name)
+        if adapter_path is None:
+            return
+
+        active_adapter = getattr(self.inference_system, "_active_adapter", None)
+        try:
+            self.inference_system.set_active_adapter(expert_name)
+            self._expert_ready[expert_name] = True
+            logger.info(
+                "Primed %s expert using adapter at %s", expert_name, adapter_path
+            )
+        except Exception as exc:
+            self._expert_ready[expert_name] = False
+            logger.error(
+                "Failed to prime %s expert from %s: %s",
+                expert_name,
+                adapter_path,
+                exc,
+            )
+        finally:
+            if active_adapter and active_adapter != expert_name:
+                try:
+                    self.inference_system.set_active_adapter(active_adapter)
+                except Exception:
+                    logger.debug(
+                        "Unable to restore previous adapter %s after priming %s",
+                        active_adapter,
+                        expert_name,
+                    )
+
+    def _ensure_expert_ready(self, expert_name: str) -> None:
+        if expert_name not in self._expert_adapter_paths:
+            return
+
+        if not self._expert_ready.get(expert_name):
+            self.prime_available_experts()
+            if (
+                not self._expert_ready.get(expert_name)
+                and expert_name not in self._missing_expert_logged
+            ):
+                logger.warning(
+                    "Expert %s is not primed; using fallback behaviour", expert_name
+                )
+                self._missing_expert_logged.add(expert_name)
 
     def analyze_position(self, fen: str, query_type: str = "auto",
                         complexity_score: Optional[float] = None) -> Dict[str, Any]:
@@ -656,6 +745,7 @@ class MoEInferenceManager:
 
     def _execute_single_expert_inference(self, fen: str, expert_name: str) -> Dict[str, Any]:
         """Execute inference with a single expert."""
+        self._ensure_expert_ready(expert_name)
         if self.inference_system:
             try:
                 # Switch to the correct expert


### PR DESCRIPTION
## Summary
- load the saved MoE router checkpoint during inference bootstrap and fall back to single-expert mode when checkpoints are missing
- prime each expert adapter through the shared inference object so routing decisions hit real adapters and add defensive logging around priming
- document the expected MoE checkpoint directory layout and add helper utilities for locating router files

## Testing
- pytest tests/test_moe_router.py
- pytest tests/test_inference.py *(fails: ImportError: cannot import name 'EncoderDecoderCache' from 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68cdda54ac608323950b3e3bec107dd0