### PR TITLE
Fix king safety scoring for both colors

### DIFF
--- a/src/inference/moe_router.py
+++ b/src/inference/moe_router.py
@@ -336,8 +336,12 @@ class ChessMoERouter(nn.Module):
         # Simplified king safety assessment
         king_positions = self._find_kings(board)
 
-        white_safety = self._calculate_king_safety_score(board, king_positions['white'])
-        black_safety = self._calculate_king_safety_score(board, king_positions['black'])
+        white_safety = self._calculate_king_safety_score(
+            board, king_positions['white'], 'white'
+        )
+        black_safety = self._calculate_king_safety_score(
+            board, king_positions['black'], 'black'
+        )
 
         return (white_safety + black_safety) / 2
 
@@ -354,7 +358,12 @@ class ChessMoERouter(nn.Module):
 
         return positions
 
-    def _calculate_king_safety_score(self, board: List[List[str]], king_pos: Tuple[int, int]) -> float:
+    def _calculate_king_safety_score(
+        self,
+        board: List[List[str]],
+        king_pos: Tuple[int, int],
+        king_color: Optional[str] = None
+    ) -> float:
         """Calculate safety score for a king position."""
         if not king_pos:
             return 0.5
@@ -362,6 +371,25 @@ class ChessMoERouter(nn.Module):
         i, j = king_pos
         defenders = 0
         attackers = 0
+
+        # Determine king color if not provided
+        square_piece = board[i][j] if 0 <= i < 8 and 0 <= j < 8 else ''
+        is_white = None
+        if king_color is not None:
+            if king_color in ('K', 'k'):
+                is_white = king_color == 'K'
+            else:
+                lowered = king_color.lower()
+                if lowered in ('white', 'w'):
+                    is_white = True
+                elif lowered in ('black', 'b'):
+                    is_white = False
+
+        if is_white is None and square_piece:
+            is_white = square_piece.isupper()
+
+        if is_white is None:
+            return 0.5
 
         # Check adjacent squares for defenders/attackers
         for di in [-1, 0, 1]:
@@ -373,10 +401,16 @@ class ChessMoERouter(nn.Module):
                 if 0 <= ni < 8 and 0 <= nj < 8:
                     piece = board[ni][nj]
                     if piece:
-                        if piece.isupper():  # White piece near white king
-                            defenders += 1
-                        else:  # Black piece near white king
-                            attackers += 1
+                        if is_white:
+                            if piece.isupper():
+                                defenders += 1
+                            elif piece.islower():
+                                attackers += 1
+                        else:
+                            if piece.islower():
+                                defenders += 1
+                            elif piece.isupper():
+                                attackers += 1
 
         total_pieces = defenders + attackers
         return defenders / max(total_pieces, 1)

--- a/tests/test_moe_router.py
+++ b/tests/test_moe_router.py
@@ -25,3 +25,39 @@ def test_route_query_deterministic_expert_selection():
     experts = [router.route_query(fen).primary_expert for _ in range(5)]
 
     assert len(set(experts)) == 1, "Expert selection should be deterministic"
+
+
+def _king_safety_score(router: ChessMoERouter, fen: str, color: str) -> float:
+    board = router._fen_to_board(fen)
+    kings = router._find_kings(board)
+    return router._calculate_king_safety_score(board, kings[color], color)
+
+
+def test_king_safety_improves_with_white_defenders():
+    router = ChessMoERouter()
+
+    exposed = "4k3/8/8/8/8/8/8/4K3 w - - 0 1"
+    defended = "4k3/8/8/8/8/8/3PPP2/4K3 w - - 0 1"
+    under_attack = "4k3/8/8/8/8/8/3PPP2/3rKr2 w - - 0 1"
+
+    exposed_score = _king_safety_score(router, exposed, 'white')
+    defended_score = _king_safety_score(router, defended, 'white')
+    attacked_score = _king_safety_score(router, under_attack, 'white')
+
+    assert defended_score > exposed_score
+    assert attacked_score < defended_score
+
+
+def test_king_safety_improves_with_black_defenders():
+    router = ChessMoERouter()
+
+    exposed = "4k3/8/8/8/8/8/8/4K3 w - - 0 1"
+    defended = "4k3/3ppp2/8/8/8/8/8/4K3 w - - 0 1"
+    under_attack = "3RkR2/3ppp2/8/8/8/8/8/4K3 w - - 0 1"
+
+    exposed_score = _king_safety_score(router, exposed, 'black')
+    defended_score = _king_safety_score(router, defended, 'black')
+    attacked_score = _king_safety_score(router, under_attack, 'black')
+
+    assert defended_score > exposed_score
+    assert attacked_score < defended_score


### PR DESCRIPTION
## Summary
- normalize king safety calculations to count friendly defenders and enemy attackers relative to each king
- pass explicit colors from the king safety assessment helper
- add regression-style tests for white and black kings covering defenders and attackers scenarios

## Testing
- pytest tests/test_moe_router.py

------
https://chatgpt.com/codex/tasks/task_e_68cdda55f55083239322012b723f72fe