### PR TITLE
Handle missing torch in error handler

### DIFF
--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -17,6 +17,11 @@ from contextlib import contextmanager
 import threading
 import psutil
 
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -296,10 +301,28 @@ class ChessGemmaErrorHandler:
     def _clear_model_cache(self, error_record: ErrorRecord) -> Dict[str, Any]:
         """Clear model cache to free memory."""
         try:
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-            elif hasattr(torch, 'mps') and torch.backends.mps.is_available():
-                torch.mps.empty_cache()
+            if torch is None:
+                logger.debug("PyTorch not available; skipping GPU/MPS cache cleanup.")
+            else:
+                cuda_available = (
+                    hasattr(torch, 'cuda')
+                    and hasattr(torch.cuda, 'is_available')
+                    and callable(torch.cuda.is_available)
+                    and torch.cuda.is_available()
+                )
+                if cuda_available and hasattr(torch.cuda, 'empty_cache') and callable(torch.cuda.empty_cache):
+                    torch.cuda.empty_cache()
+                else:
+                    mps_available = (
+                        hasattr(torch, 'mps')
+                        and hasattr(torch, 'backends')
+                        and hasattr(torch.backends, 'mps')
+                        and hasattr(torch.backends.mps, 'is_available')
+                        and callable(torch.backends.mps.is_available)
+                        and torch.backends.mps.is_available()
+                    )
+                    if mps_available and hasattr(torch.mps, 'empty_cache') and callable(torch.mps.empty_cache):
+                        torch.mps.empty_cache()
             import gc
             gc.collect()
             return {'success': True, 'message': 'Model cache cleared'}

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Unit tests for the error handler utilities."""
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure project root is on the Python path
+project_root = Path(__file__).parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from src.utils import error_handler as error_handler_module
+
+
+@pytest.fixture
+def error_handler(monkeypatch):
+    """Provide a fresh error handler instance for each test."""
+    # Default to no torch for predictable fixture behaviour
+    monkeypatch.setattr(error_handler_module, "torch", None)
+    return error_handler_module.ChessGemmaErrorHandler()
+
+
+def test_clear_model_cache_without_torch(caplog, error_handler):
+    """Ensure cache clearing works gracefully without PyTorch installed."""
+    caplog.set_level(logging.DEBUG, logger=error_handler_module.logger.name)
+
+    with patch("gc.collect") as mock_collect:
+        mock_collect.return_value = 0
+        result = error_handler._clear_model_cache(None)
+
+    assert result["success"] is True
+    mock_collect.assert_called_once()
+    assert "PyTorch not available" in caplog.text
+
+
+def test_clear_model_cache_with_torch_cuda(monkeypatch):
+    """Ensure GPU cache clearing is attempted when CUDA is available."""
+    cuda_calls = {"empty_cache": 0}
+
+    def fake_is_available():
+        return True
+
+    def fake_empty_cache():
+        cuda_calls["empty_cache"] += 1
+
+    dummy_cuda = types.SimpleNamespace(
+        is_available=fake_is_available,
+        empty_cache=fake_empty_cache,
+    )
+
+    dummy_torch = types.SimpleNamespace(
+        cuda=dummy_cuda,
+        backends=types.SimpleNamespace(),
+    )
+
+    monkeypatch.setattr(error_handler_module, "torch", dummy_torch)
+    handler = error_handler_module.ChessGemmaErrorHandler()
+
+    with patch("gc.collect") as mock_collect:
+        mock_collect.return_value = 0
+        result = handler._clear_model_cache(None)
+
+    assert result["success"] is True
+    assert cuda_calls["empty_cache"] == 1


### PR DESCRIPTION
## Summary
- add a guarded import for torch in the error handler utilities
- skip accelerator cache cleanup when torch is unavailable and log the decision
- exercise the cache clearing helper with and without torch via new unit tests

## Testing
- pytest tests/test_error_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a4482aec8323af54937d0173df7f