### PR TITLE
Implement engine-backed move quality evaluation

### DIFF
--- a/src/evaluation/advanced_benchmark.py
+++ b/src/evaluation/advanced_benchmark.py
@@ -19,6 +19,12 @@ import logging
 from collections import defaultdict
 import scipy.stats as stats
 
+import chess
+import chess.engine
+
+from src.inference.chess_engine import ChessEngineManager
+from src.inference.uci_utils import extract_first_uci
+
 logger = logging.getLogger(__name__)
 
 
@@ -148,10 +154,11 @@ class ChessGemmaBenchmarker:
         # Check for regressions
         regression_analysis = self._analyze_regression(benchmark_result)
         if regression_analysis.is_regression:
-            logger.warning("⚠️  Performance regression detected!"            self._log_regression_alert(benchmark_result, regression_analysis)
+            logger.warning("⚠️  Performance regression detected!")
+            self._log_regression_alert(benchmark_result, regression_analysis)
 
         total_time = time.time() - start_time
-        logger.info(".2f"
+        logger.info(f"Benchmark completed in {total_time:.2f}s")
         return benchmark_result
 
     def _evaluate_result(self, test_case: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
@@ -271,9 +278,72 @@ class ChessGemmaBenchmarker:
 
     def _evaluate_move_quality(self, test_case: Dict[str, Any], result: Dict[str, Any]) -> float:
         """Evaluate chess move quality."""
-        # Placeholder for chess engine integration
-        # This would use Stockfish or similar to evaluate move quality
-        return 0.5  # Neutral score for now
+        fen = test_case.get('fen') or test_case.get('FEN')
+        if not fen:
+            return 0.0
+
+        # Extract the candidate move from structured result data or free-form text
+        move = (
+            result.get('move')
+            or result.get('uci')
+            or extract_first_uci(result.get('response', ''))
+        )
+        if not move:
+            return 0.0
+
+        move = move.strip().lower()
+
+        try:
+            board = chess.Board(fen)
+        except Exception:
+            logger.warning("Invalid FEN provided for move quality evaluation")
+            return 0.0
+
+        try:
+            move_obj = chess.Move.from_uci(move)
+        except ValueError:
+            # Fall back to SAN parsing for descriptive moves
+            try:
+                move_obj = board.parse_san(move)
+            except Exception:
+                return 0.0
+
+        if move_obj not in board.legal_moves:
+            return 0.0
+
+        player_to_move = board.turn
+
+        def score_to_cp(score: Optional[chess.engine.PovScore]) -> Optional[float]:
+            if not score:
+                return None
+            try:
+                return float(score.pov(player_to_move).score(mate_score=100000))
+            except Exception:
+                return None
+
+        try:
+            with ChessEngineManager() as engine_manager:
+                analysis_limit = chess.engine.Limit(depth=12, time=0.5)
+
+                best_info = engine_manager.engine.analyse(board, analysis_limit)
+                best_cp = score_to_cp(best_info.get('score'))
+
+                candidate_board = board.copy()
+                candidate_board.push(move_obj)
+                candidate_info = engine_manager.engine.analyse(candidate_board, analysis_limit)
+                candidate_cp = score_to_cp(candidate_info.get('score'))
+        except Exception as exc:
+            logger.warning(f"Move quality evaluation failed: {exc}")
+            return 0.0
+
+        if best_cp is None or candidate_cp is None:
+            return 0.0
+
+        cp_loss = max(0.0, best_cp - candidate_cp)
+        max_loss = 600.0  # Treat any loss >= 6 pawns as a blunder
+        quality = 1.0 - min(cp_loss, max_loss) / max_loss
+
+        return max(0.0, min(1.0, quality))
 
     def _evaluate_reasoning_quality(self, response: str) -> float:
         """Evaluate reasoning quality in CoT responses."""

--- a/tests/test_advanced_benchmark.py
+++ b/tests/test_advanced_benchmark.py
@@ -1,0 +1,108 @@
+"""Tests for advanced benchmark move quality evaluation."""
+
+from typing import List
+from unittest.mock import patch
+from pathlib import Path
+import sys
+
+import chess
+import chess.engine
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.evaluation.advanced_benchmark import ChessGemmaBenchmarker
+
+
+class FakeEngine:
+    """Minimal engine stub returning predetermined scores."""
+
+    def __init__(self, scores: List[chess.engine.PovScore]):
+        self._scores = scores
+        self._call_count = 0
+
+    def analyse(self, board: chess.Board, limit: chess.engine.Limit):  # type: ignore[override]
+        index = min(self._call_count, len(self._scores) - 1)
+        self._call_count += 1
+        return {'score': self._scores[index]}
+
+
+class FakeManager:
+    """Context manager stub that records cleanup usage."""
+
+    instances: List["FakeManager"] = []
+
+    def __init__(self, scores: List[chess.engine.PovScore]):
+        self.engine = FakeEngine(scores)
+        self.cleaned = False
+        FakeManager.instances.append(self)
+
+    def __enter__(self) -> "FakeManager":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        self.cleaned = True
+
+
+def _make_score(cp: int, color: chess.Color = chess.WHITE) -> chess.engine.PovScore:
+    return chess.engine.PovScore(chess.engine.Cp(cp), color)
+
+
+def test_move_quality_prefers_best_move() -> None:
+    benchmark = ChessGemmaBenchmarker()
+    fen = chess.STARTING_BOARD_FEN
+
+    best_score = _make_score(80)
+    equal_candidate = _make_score(80)
+    poor_candidate = _make_score(-400)
+
+    FakeManager.instances = []
+    with patch(
+        "src.evaluation.advanced_benchmark.ChessEngineManager",
+        side_effect=lambda: FakeManager([best_score, equal_candidate]),
+    ):
+        good_quality = benchmark._evaluate_move_quality({'fen': fen}, {'move': 'e2e4'})
+
+    FakeManager.instances = []
+    with patch(
+        "src.evaluation.advanced_benchmark.ChessEngineManager",
+        side_effect=lambda: FakeManager([best_score, poor_candidate]),
+    ):
+        bad_quality = benchmark._evaluate_move_quality({'fen': fen}, {'move': 'a2a3'})
+
+    assert 0.0 <= good_quality <= 1.0
+    assert 0.0 <= bad_quality <= 1.0
+    assert good_quality > bad_quality
+
+
+def test_move_quality_uses_response_text_and_cleans_up() -> None:
+    benchmark = ChessGemmaBenchmarker()
+    fen = chess.STARTING_BOARD_FEN
+
+    best_score = _make_score(0)
+    candidate_score = _make_score(0)
+
+    FakeManager.instances = []
+    with patch(
+        "src.evaluation.advanced_benchmark.ChessEngineManager",
+        side_effect=lambda: FakeManager([best_score, candidate_score]),
+    ):
+        quality = benchmark._evaluate_move_quality({'fen': fen}, {'response': 'I choose e2e4'})
+
+    assert quality > 0.0
+    assert FakeManager.instances, "Engine manager should have been instantiated"
+    assert all(instance.cleaned for instance in FakeManager.instances)
+
+
+def test_move_quality_handles_missing_data() -> None:
+    benchmark = ChessGemmaBenchmarker()
+
+    with patch("src.evaluation.advanced_benchmark.ChessEngineManager") as manager_cls:
+        score = benchmark._evaluate_move_quality({}, {'response': 'e2e4'})
+
+    assert score == 0.0
+    manager_cls.assert_not_called()


### PR DESCRIPTION
## Summary
- replace the placeholder move-quality logic with a Stockfish-backed centipawn-loss metric
- fix minor logging issues in the benchmarker and ensure regression alerts log correctly
- add unit tests that simulate engine feedback and verify higher scores for strong moves than blunders

## Testing
- pytest tests/test_advanced_benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68e414e82c208323af45060ff11fe265