### PR TITLE
Fix advanced benchmark logging and add regression test

### DIFF
--- a/src/evaluation/advanced_benchmark.py
+++ b/src/evaluation/advanced_benchmark.py
@@ -148,10 +148,11 @@ class ChessGemmaBenchmarker:
         # Check for regressions
         regression_analysis = self._analyze_regression(benchmark_result)
         if regression_analysis.is_regression:
-            logger.warning("⚠️  Performance regression detected!"            self._log_regression_alert(benchmark_result, regression_analysis)
+            logger.warning("⚠️  Performance regression detected!")
+            self._log_regression_alert(benchmark_result, regression_analysis)
 
         total_time = time.time() - start_time
-        logger.info(".2f"
+        logger.info("✅ Benchmark completed in %.2fs", total_time)
         return benchmark_result
 
     def _evaluate_result(self, test_case: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
@@ -428,18 +429,20 @@ class ChessGemmaBenchmarker:
 
     def _log_regression_alert(self, result: BenchmarkResult, analysis: RegressionAnalysis):
         """Log regression alert with details."""
-        alert_msg = ".1f"".2f"f"""
-⚠️  PERFORMANCE REGRESSION ALERT ⚠️
+        actions_text = "\n".join(f"- {action}" for action in analysis.recommended_actions)
+        if not actions_text:
+            actions_text = "- No specific actions recommended"
 
-Model: {result.model_name}
-Timestamp: {result.timestamp}
-Confidence: {analysis.confidence_level:.1%}
-Magnitude: {analysis.regression_magnitude:.1%}
-Affected Metrics: {', '.join(analysis.affected_metrics)}
-
-Recommended Actions:
-{chr(10).join(f"- {action}" for action in analysis.recommended_actions)}
-"""
+        alert_msg = (
+            "⚠️  PERFORMANCE REGRESSION ALERT ⚠️\n\n"
+            f"Model: {result.model_name}\n"
+            f"Timestamp: {result.timestamp}\n"
+            f"Confidence: {analysis.confidence_level:.1%}\n"
+            f"Magnitude: {analysis.regression_magnitude:.1%}\n"
+            f"Affected Metrics: {', '.join(analysis.affected_metrics) or 'None'}\n\n"
+            "Recommended Actions:\n"
+            f"{actions_text}"
+        )
         logger.warning(alert_msg)
 
         # Save regression report

--- a/tests/test_advanced_benchmark.py
+++ b/tests/test_advanced_benchmark.py
@@ -1,0 +1,52 @@
+"""Regression tests for the advanced benchmark module."""
+
+from pathlib import Path
+import sys
+
+
+# Ensure the repository root (containing the ``src`` package) is importable.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.evaluation.advanced_benchmark import (  # noqa: E402  (import after path setup)
+    BenchmarkResult,
+    ChessGemmaBenchmarker,
+)
+
+
+def test_run_comprehensive_benchmark_returns_result(tmp_path):
+    """Ensure running the benchmark on a small dataset succeeds."""
+
+    benchmarker = ChessGemmaBenchmarker(results_dir=tmp_path)
+
+    dataset = [
+        {
+            "prompt": "FEN: start position\nWhat is the best move for white?",
+            "expected": "e2e4",
+            "task": "engine_uci",
+        },
+        {
+            "prompt": "Explain basic opening principles.",
+            "expected": "Control the center",
+            "task": "tutor_explain",
+        },
+        {
+            "prompt": "What strategic plan should white follow?",
+            "expected": "Develop pieces",
+            "task": "director_qa",
+        },
+    ]
+
+    def inference_func(test_case):
+        return {"response": test_case.get("expected", "")}
+
+    result = benchmarker.run_comprehensive_benchmark(
+        "test-model",
+        inference_func,
+        dataset,
+    )
+
+    assert isinstance(result, BenchmarkResult)
+    assert result.model_name == "test-model"
+    assert len(result.test_cases) == len(dataset)


### PR DESCRIPTION
## Summary
- fix malformed logging around regression detection in the advanced benchmarker
- add a regression test ensuring run_comprehensive_benchmark returns a BenchmarkResult on synthetic data

## Testing
- pytest tests/test_advanced_benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68e414eecd9c8323a020c0beb2289726