### PR TITLE
Add LC0 tutor dataset generation and adjust training mix

### DIFF
--- a/scripts/generate_evaluation_data.py
+++ b/scripts/generate_evaluation_data.py
@@ -6,7 +6,7 @@ This script samples high-quality records from the standardized training corpora
 and produces curated evaluation files with consistent schemas:
 
   - data/validation/eval_mixed_positions_200.jsonl
-  - data/validation/tutor_comprehensive_validation.json
+  - data/validation/tutor_comprehensive_validation.json (hybrid LC0+LLM references)
   - data/validation/director_comprehensive_validation.json
 
 No synthetic placeholders are introduced; all samples come directly from the
@@ -27,7 +27,8 @@ STANDARDIZED_DIR = PROJECT_ROOT / "data" / "standardized"
 VALIDATION_DIR = PROJECT_ROOT / "data" / "validation"
 
 UCI_SOURCE = STANDARDIZED_DIR / "standardized_uci_expert_v2.jsonl"
-TUTOR_SOURCE = STANDARDIZED_DIR / "standardized_tutor_expert_v2.jsonl"
+TUTOR_SOURCE = STANDARDIZED_DIR / "standardized_tutor_lc0_v1.jsonl"
+LEGACY_TUTOR_SOURCE = STANDARDIZED_DIR / "standardized_tutor_expert_v2.jsonl"
 DIRECTOR_SOURCE = STANDARDIZED_DIR / "standardized_director_expert_v3.jsonl"
 
 UCI_OUTPUT = VALIDATION_DIR / "eval_mixed_positions_200.jsonl"
@@ -105,7 +106,11 @@ def pick_uci_positions(limit: int = 200) -> None:
 
 def pick_tutor_puzzles(limit: int = 80) -> None:
     puzzles = []
-    candidate_rows = list(load_jsonl(TUTOR_SOURCE))
+    tutor_source = TUTOR_SOURCE if TUTOR_SOURCE.exists() else LEGACY_TUTOR_SOURCE
+    if tutor_source != TUTOR_SOURCE:
+        print(f"⚠️  Using legacy tutor dataset at {tutor_source}")
+
+    candidate_rows = list(load_jsonl(tutor_source))
     RANDOM.shuffle(candidate_rows)
 
     for row in candidate_rows:
@@ -128,16 +133,31 @@ def pick_tutor_puzzles(limit: int = 80) -> None:
         if not best_move:
             continue
 
+        engine_move = meta.get("engine_move") or best_move
+        principal_variation = meta.get("principal_variation") or []
+        engine_eval_cp = meta.get("engine_evaluation_cp")
+        engine_eval_pawns = meta.get("engine_evaluation_pawns")
         rating = meta.get("rating")
         puzzles.append({
             "id": f"tutor-{len(puzzles)+1:04d}",
             "fen": fen,
-            "expected_move": best_move,
+            "expected_move": engine_move,
             "rating": rating,
             "difficulty": difficulty_from_rating(rating),
             "question": prompt.strip(),
             "reference_analysis": response.strip(),
-            "source": meta.get("source", "standardized_tutor_expert"),
+            "engine_move": engine_move,
+            "principal_variation": principal_variation,
+            "engine_evaluation_cp": engine_eval_cp,
+            "engine_evaluation_pawns": engine_eval_pawns,
+            "hybrid_reference": {
+                "analysis": response.strip(),
+                "engine": meta.get("engine"),
+                "engine_move": engine_move,
+                "principal_variation": principal_variation,
+                "key_points": meta.get("hybrid_key_points", []),
+            },
+            "source": meta.get("source", tutor_source.stem),
         })
 
         if len(puzzles) >= limit:
@@ -148,7 +168,7 @@ def pick_tutor_puzzles(limit: int = 80) -> None:
 
     payload = {
         "metadata": {
-            "generated_from": str(TUTOR_SOURCE),
+            "generated_from": str(tutor_source),
             "sample_size": len(puzzles),
             "seed": SAMPLE_SEED,
         },
@@ -175,13 +195,22 @@ def pick_director_questions(limit: int = 80) -> None:
         category = meta.get("topic", "general")
         rating = meta.get("rating")
 
+        hybrid_reference = {
+            "analysis": response.strip(),
+            "engine": meta.get("engine"),
+            "engine_move": meta.get("engine_move"),
+            "principal_variation": meta.get("principal_variation") or [],
+        }
+
         questions.append({
             "id": f"director-{len(questions)+1:04d}",
             "question": prompt.strip(),
             "expected_answer": response.strip(),
+            "reference_answer": response.strip(),
             "category": category,
             "rating": rating,
             "best_move": meta.get("best_move"),
+            "hybrid_reference": hybrid_reference,
             "source": meta.get("source", "standardized_director_expert_v2"),
         })
 

--- a/scripts/refresh_expert_datasets.py
+++ b/scripts/refresh_expert_datasets.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """Refresh tutor/director expert datasets with cleaned, augmented entries.
 
-- deduplicate by FEN/prompt combination
-- ensure tutor responses end with ``best move: <uci>``
-- ensure director responses end with ``Final move (UCI): <uci>`` when available
-- append curated evaluation puzzles/questions to broaden coverage
+- Deduplicate by FEN/prompt combination
+- Ensure tutor responses end with ``best move: <uci>``
+- Ensure director responses end with ``Final move (UCI): <uci>`` when available
+- Optionally generate an LC0-labelled tutor split with hybrid explanations
+  saved to ``data/standardized/standardized_tutor_lc0_v1.jsonl``
 """
 from __future__ import annotations
 
+import argparse
 import json
+import logging
+import random
 import re
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -23,6 +27,7 @@ DIRECTOR_SOURCE = STANDARDIZED_DIR / "standardized_director_expert_v2.jsonl"
 
 TUTOR_OUTPUT = STANDARDIZED_DIR / "standardized_tutor_expert_v2.jsonl"
 DIRECTOR_OUTPUT = STANDARDIZED_DIR / "standardized_director_expert_v3.jsonl"
+TUTOR_LC0_OUTPUT = STANDARDIZED_DIR / "standardized_tutor_lc0_v1.jsonl"
 
 TUTOR_EVAL = VALIDATION_DIR / "tutor_comprehensive_validation.json"
 DIRECTOR_EVAL = VALIDATION_DIR / "director_comprehensive_validation.json"
@@ -31,6 +36,13 @@ DIRECTOR_EVAL = VALIDATION_DIR / "director_comprehensive_validation.json"
 BEST_MOVE_PATTERN = re.compile(r"best move:\s*([a-h][1-8][a-h][1-8][qrbn]?)", re.IGNORECASE)
 FINAL_MOVE_PATTERN = re.compile(r"final move\s*\(uci\):\s*([a-h][1-8][a-h][1-8][qrbn]?)", re.IGNORECASE)
 UCI_PATTERN = re.compile(r"^[a-h][1-8][a-h][1-8][qrbn]?$")
+
+RNG = random.Random(3407)
+
+try:  # Lazy import so offline environments can still refresh baselines
+    from src.inference.inference import get_inference_instance
+except Exception:  # pragma: no cover - optional dependency
+    get_inference_instance = None
 
 
 def load_jsonl(path: Path) -> Iterable[Dict[str, object]]:
@@ -146,6 +158,98 @@ def process_tutor_dataset() -> List[Dict[str, object]]:
     return records
 
 
+def _normalize_hybrid_response(text: str, engine_move: str) -> str:
+    """Ensure the hybrid explanation ends with a best-move line."""
+
+    body = text.strip()
+    if body and not body.endswith("\n"):
+        body += "\n"
+    if f"best move: {engine_move}".lower() not in body.lower():
+        body += f"Best move: {engine_move}"
+    return body
+
+
+def generate_lc0_tutor_dataset(
+    base_records: List[Dict[str, object]],
+    *,
+    limit: Optional[int] = None,
+) -> List[Dict[str, object]]:
+    """Run LC0 hybrid analysis over tutor prompts to build labelled samples."""
+
+    if get_inference_instance is None:
+        raise RuntimeError(
+            "LC0 inference stack is unavailable. Install dependencies and ensure "
+            "the inference package can be imported."
+        )
+
+    inference = get_inference_instance()
+    inference.load_model()
+
+    candidates = [rec for rec in base_records if rec.get("meta", {}).get("fen")]
+    RNG.shuffle(candidates)
+
+    seen_fens: set[str] = set()
+    enriched: List[Dict[str, object]] = []
+
+    for record in candidates:
+        if limit is not None and len(enriched) >= limit:
+            break
+
+        meta = record.get("meta") or {}
+        fen = meta.get("fen")
+        if not fen or fen in seen_fens:
+            continue
+
+        prompt = record.get("prompt") or ""
+
+        try:
+            engine_payload = inference.analyze_with_engine(fen, explanation_mode="tutor")
+        except Exception as exc:  # pragma: no cover - engine failures are rare
+            logging.warning("LC0 analysis failed for %s: %s", fen, exc)
+            continue
+
+        engine_move = engine_payload.get("best_move")
+        if not engine_move:
+            continue
+
+        explanation = engine_payload.get("explanation") or record.get("response") or ""
+        normalized_response = _normalize_hybrid_response(explanation, engine_move)
+
+        principal_variation = engine_payload.get("principal_variation") or []
+
+        enriched_meta = dict(meta)
+        enriched_meta.update(
+            {
+                "engine": engine_payload.get("engine"),
+                "engine_move": engine_move,
+                "engine_evaluation_cp": engine_payload.get("evaluation_cp"),
+                "engine_evaluation_pawns": engine_payload.get("evaluation_pawns"),
+                "engine_mate_in": engine_payload.get("mate_in"),
+                "engine_depth": engine_payload.get("depth"),
+                "engine_nodes": engine_payload.get("nodes"),
+                "engine_time": engine_payload.get("engine_time"),
+                "principal_variation": principal_variation,
+                "hybrid_key_points": engine_payload.get("key_points", []),
+                "explanation_adapter": engine_payload.get("explanation_adapter"),
+                "engine_source": "lc0_hybrid_v1",
+                "source": "standardized_tutor_lc0_v1",
+            }
+        )
+        enriched_meta.setdefault("quality_score", meta.get("quality_score", 0.9))
+
+        enriched.append(
+            {
+                "task": "tutor_explain",
+                "prompt": prompt,
+                "response": normalized_response,
+                "meta": enriched_meta,
+            }
+        )
+        seen_fens.add(fen)
+
+    return enriched
+
+
 def process_director_dataset() -> List[Dict[str, object]]:
     records: List[Dict[str, object]] = []
     seen_questions: set[str] = set()
@@ -201,6 +305,20 @@ def process_director_dataset() -> List[Dict[str, object]]:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Refresh standardized expert datasets.")
+    parser.add_argument(
+        "--skip-lc0",
+        action="store_true",
+        help="Skip generating the LC0-labelled tutor dataset.",
+    )
+    parser.add_argument(
+        "--lc0-limit",
+        type=int,
+        default=None,
+        help="Cap the number of LC0 tutor samples (defaults to all available prompts).",
+    )
+    args = parser.parse_args()
+
     tutor_records = process_tutor_dataset()
     director_records = process_director_dataset()
 
@@ -209,6 +327,18 @@ def main() -> None:
 
     print(f"✅ Tutor dataset written to {TUTOR_OUTPUT} ({len(tutor_records)} entries)")
     print(f"✅ Director dataset written to {DIRECTOR_OUTPUT} ({len(director_records)} entries)")
+
+    if not args.skip_lc0:
+        try:
+            lc0_records = generate_lc0_tutor_dataset(tutor_records, limit=args.lc0_limit)
+        except RuntimeError as exc:
+            logging.warning("Skipping LC0 tutor generation: %s", exc)
+        else:
+            save_jsonl(lc0_records, TUTOR_LC0_OUTPUT)
+            print(
+                f"✅ LC0 tutor dataset written to {TUTOR_LC0_OUTPUT} "
+                f"({len(lc0_records)} entries)"
+            )
 
 
 if __name__ == "__main__":

--- a/src/training/dataset_mixer.py
+++ b/src/training/dataset_mixer.py
@@ -25,6 +25,8 @@ def _load_single_jsonl(
     *,
     streaming: bool = False,
     cache_dir: Optional[str] = None,
+    drop_tasks: Optional[List[str]] = None,
+    keep_tasks: Optional[List[str]] = None,
 ) -> Dataset | IterableDataset:
     """Load a JSONL dataset and normalize its columns.
 
@@ -81,6 +83,23 @@ def _load_single_jsonl(
     # Map lazily and drop any unexpected columns
     extra_cols = [c for c in ds.column_names if c not in expected_cols]
     ds = ds.map(_normalize, remove_columns=extra_cols)
+
+    if (drop_tasks or keep_tasks) and streaming:
+        raise ValueError("Task filtering is not supported in streaming mode.")
+
+    if drop_tasks or keep_tasks:
+        drop_set = {t.lower() for t in drop_tasks or []}
+        keep_set = {t.lower() for t in keep_tasks or []} or None
+
+        def _task_filter(example: Dict[str, Any]) -> bool:
+            task_name = (example.get("task") or "").lower()
+            if keep_set is not None and task_name not in keep_set:
+                return False
+            if drop_set and (task_name in drop_set or any(task_name.startswith(prefix) for prefix in drop_set)):
+                return False
+            return True
+
+        ds = ds.filter(_task_filter)
     return ds
 
 
@@ -93,7 +112,16 @@ def build_mixture(
 ) -> Dataset | IterableDataset:
     """Build an interleaved mixture from dataset specs.
 
-    dataset_specs: list of { 'path': str, 'weight': float }
+    ``dataset_specs`` accepts dictionaries with the following keys::
+
+        {
+            'path': str,
+            'weight': float,
+            'drop_tasks': List[str],      # optional task blacklist
+            'keep_tasks': List[str],      # optional task whitelist
+            'drop_engine_uci': bool,      # convenience flag
+        }
+
     Weights are normalized automatically.
     """
     if not dataset_specs:
@@ -110,7 +138,18 @@ def build_mixture(
         if weight <= 0:
             # Skip zero/negative weights
             continue
-        ds = _load_single_jsonl(path, streaming=streaming, cache_dir=cache_dir)
+        drop_tasks = spec.get('drop_tasks')
+        keep_tasks = spec.get('keep_tasks')
+        if spec.get('drop_engine_uci'):
+            drop_tasks = list(drop_tasks or []) + ['engine_uci']
+
+        ds = _load_single_jsonl(
+            path,
+            streaming=streaming,
+            cache_dir=cache_dir,
+            drop_tasks=drop_tasks,
+            keep_tasks=keep_tasks,
+        )
         datasets_list.append(ds)
         weights.append(weight)
 

--- a/src/training/train_lora_poc.py
+++ b/src/training/train_lora_poc.py
@@ -593,6 +593,19 @@ def main():
                 from src.training.dataset_mixer import _load_single_jsonl
                 ds = _load_single_jsonl(ds_path)
 
+        if ds is not None and args.expert not in ('uci',):
+            try:
+                initial_size = len(ds) if hasattr(ds, '__len__') else None
+                ds = ds.filter(lambda ex: (ex.get('task') or '') != 'engine_uci')
+                if initial_size is not None:
+                    removed = initial_size - len(ds)
+                    if removed > 0:
+                        print(f"Filtered out {removed} engine_uci samples from training mix")
+                else:
+                    print("Filtered engine_uci tasks from streaming dataset")
+            except Exception as exc:
+                print(f"Warning: unable to filter engine_uci tasks ({exc}); proceeding without removal")
+
         # Optional expert filtering by task field
         if ds is not None and args.expert != 'all':
             task_map = {'uci': 'engine_uci', 'tutor': 'tutor_explain', 'director': 'director_qa'}


### PR DESCRIPTION
## Summary
- extend the dataset refresh script to optionally generate an LC0-labelled tutor split with hybrid analysis metadata
- add task filtering support to the dataset mixer and drop engine_uci samples from the LoRA training path
- refresh evaluation data generation to consume the LC0 tutor corpus and emit hybrid reference metadata

## Testing
- python -m compileall scripts/refresh_expert_datasets.py src/training/dataset_mixer.py src/training/train_lora_poc.py scripts/generate_evaluation_data.py

------
https://chatgpt.com/codex/tasks/task_e_68ed8973b6e083239a09f2ef463fcf1c