### PR TITLE
Improve core engine load synchronization

### DIFF
--- a/src/inference/core_engine.py
+++ b/src/inference/core_engine.py
@@ -67,6 +67,8 @@ class ChessGemmaCoreEngine:
         # Thread safety for model loading - use faster Lock for better performance
         self._model_load_lock = threading.Lock()
         self._model_loading = False
+        self._model_loaded_event = threading.Event()
+        self._model_loaded_event.set()
 
         # Performance monitoring - reduced overhead
         self._generation_stats = {
@@ -85,9 +87,7 @@ class ChessGemmaCoreEngine:
 
         # Thread-safe model loading - optimized double-check
         if self._model_loading:
-            # Simple busy wait for better performance
-            while self._model_loading and not self.is_loaded:
-                pass
+            self._model_loaded_event.wait()
             return self.is_loaded
 
         with self._model_load_lock:
@@ -96,19 +96,19 @@ class ChessGemmaCoreEngine:
                 return True
 
             self._model_loading = True
+            self._model_loaded_event.clear()
 
         # Allow offline benchmarking or environments without model access to
         # skip the heavyweight model loading sequence. This prevents the
         # benchmarking harness from repeatedly attempting to download weights
         # when network access is unavailable.
-        if os.environ.get("CHESSGEMMA_SKIP_MODEL_LOAD", "0") not in ("0", "false", "False"):
-            logger.warning(
-                "Skipping Gemma model load because CHESSGEMMA_SKIP_MODEL_LOAD is set."
-            )
-            self._model_loading = False
-            return False
-
         try:
+            if os.environ.get("CHESSGEMMA_SKIP_MODEL_LOAD", "0") not in ("0", "false", "False"):
+                logger.warning(
+                    "Skipping Gemma model load because CHESSGEMMA_SKIP_MODEL_LOAD is set."
+                )
+                return False
+
             if not self.model_path:
                 print("Model path not configured. Set CHESSGEMMA_MODEL_ID or CHESSGEMMA_MODEL_PATH.")
                 return False
@@ -207,16 +207,15 @@ class ChessGemmaCoreEngine:
                     print(f"Warning: Model validation error: {val_e}")
 
             self.is_loaded = True
-            self._model_loading = False  # Reset loading flag
             return True
         except Exception as e:
             print(f"Error loading model: {e}")
             self.is_loaded = False
-            self._model_loading = False  # Reset loading flag
             return False
         finally:
-            # Ensure loading flag is always reset
+            # Ensure loading flag and waiters are always reset/notified
             self._model_loading = False
+            self._model_loaded_event.set()
 
     def unload_model(self) -> None:
         """Free model resources and reset state."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -16,6 +16,8 @@ from unittest.mock import Mock, patch
 import re
 
 import torch
+import threading
+import time
 
 import chess
 
@@ -73,6 +75,7 @@ from src.inference.inference import (
     unload_model,
     get_model_info,
 )
+from src.inference.core_engine import ChessGemmaCoreEngine
 from src.inference.hybrid_engine import HybridEngineResult
 from src.inference.moe_router import RoutingDecision, MoEInferenceManager
 from src.config.config_manager import InferenceConfig
@@ -138,12 +141,75 @@ class TestChessGemmaInference:
     def test_load_model_failure(self, mock_tokenizer):
         """Test model loading failure."""
         mock_tokenizer.from_pretrained.side_effect = Exception("Load failed")
-        
+
         inference = ChessGemmaInference()
         result = inference.load_model()
-        
+
         assert result is False
         assert inference.is_loaded is False
+
+
+@patch('src.inference.core_engine.AutoTokenizer')
+@patch('src.inference.core_engine.AutoModelForCausalLM')
+def test_concurrent_model_load(mock_model_cls, mock_tokenizer_cls):
+    """Ensure concurrent load requests wait without spinning and finish safely."""
+
+    load_started = threading.Event()
+    continue_event = threading.Event()
+
+    mock_tokenizer_instance = Mock()
+
+    def slow_tokenizer(*args, **kwargs):
+        load_started.set()
+        continue_event.wait(timeout=5)
+        return mock_tokenizer_instance
+
+    mock_tokenizer_cls.from_pretrained.side_effect = slow_tokenizer
+
+    mock_model_instance = Mock()
+    mock_model_instance.to.return_value = None
+    mock_model_instance.eval.return_value = None
+    mock_model_instance.parameters.return_value = iter([Mock(device=torch.device("cpu"))])
+    mock_model_cls.from_pretrained.return_value = mock_model_instance
+
+    engine = ChessGemmaCoreEngine(model_path="mock-repo")
+
+    results = []
+
+    def loader():
+        results.append(engine.load_model())
+
+    # Start primary loader thread
+    threads = [threading.Thread(target=loader)]
+    threads[0].start()
+
+    # Wait until loading sequence has begun
+    assert load_started.wait(timeout=1), "Primary loader did not start in time"
+
+    # Start additional concurrent loaders that should block until loading completes
+    for _ in range(3):
+        t = threading.Thread(target=loader)
+        threads.append(t)
+        t.start()
+
+    # Give threads time to block on the loading event
+    time.sleep(0.1)
+    for t in threads[1:]:
+        assert t.is_alive(), "Concurrent loader thread did not wait for completion"
+
+    # Allow loading to finish
+    continue_event.set()
+
+    for t in threads:
+        t.join(timeout=2)
+        assert not t.is_alive(), "Loader thread did not terminate"
+
+    assert all(results), "All load attempts should report success"
+    assert mock_tokenizer_cls.from_pretrained.call_count == 1
+    assert mock_model_cls.from_pretrained.call_count == 1
+    assert engine.is_loaded is True
+    assert engine._model_loading is False
+    assert engine._model_loaded_event.is_set()
 
     def test_unload_model(self):
         """Test unloading frees resources and resets state."""


### PR DESCRIPTION
## Summary
- replace the busy-wait loop in ChessGemmaCoreEngine with a threading event to coordinate concurrent loaders
- ensure the loading event and flag are always reset, even on failure or skip paths
- add a concurrency-focused unit test that exercises multiple concurrent load attempts using mocks

## Testing
- pytest tests/test_inference.py::test_concurrent_model_load

------
https://chatgpt.com/codex/tasks/task_e_68f6b879a33c83238695c75075b9fceb