### PR TITLE
Fix MoE router override handling

### DIFF
--- a/src/inference/inference.py
+++ b/src/inference/inference.py
@@ -377,21 +377,21 @@ class ChessGemmaInference:
 
             if router_checkpoint is None:
                 router_dir = checkpoints_root / "moe_router"
-            router_patterns = [
-                str(router_dir / "router*.pt"),
-                str(router_dir / "router*.bin"),
-                str(router_dir / "router*.safetensors"),
-                str(router_dir / "checkpoint-*" / "router*.pt"),
-                str(router_dir / "checkpoint-*" / "*.pt"),
-                str(router_dir / "checkpoint-*" / "*.bin"),
-                str(router_dir / "checkpoint-*" / "*.safetensors"),
-                str(router_dir / "final_checkpoint.pth"),
-                str(router_dir / "best_checkpoint.pth"),
-                str(router_dir / "*.pt"),
-                str(router_dir / "*.bin"),
-                str(router_dir / "*.safetensors"),
-            ]
-            router_checkpoint = _find_latest_file(router_patterns)
+                router_patterns = [
+                    str(router_dir / "router*.pt"),
+                    str(router_dir / "router*.bin"),
+                    str(router_dir / "router*.safetensors"),
+                    str(router_dir / "checkpoint-*" / "router*.pt"),
+                    str(router_dir / "checkpoint-*" / "*.pt"),
+                    str(router_dir / "checkpoint-*" / "*.bin"),
+                    str(router_dir / "checkpoint-*" / "*.safetensors"),
+                    str(router_dir / "final_checkpoint.pth"),
+                    str(router_dir / "best_checkpoint.pth"),
+                    str(router_dir / "*.pt"),
+                    str(router_dir / "*.bin"),
+                    str(router_dir / "*.safetensors"),
+                ]
+                router_checkpoint = _find_latest_file(router_patterns)
 
             if router_checkpoint is None:
                 _disable_moe(

--- a/tests/test_moe_router.py
+++ b/tests/test_moe_router.py
@@ -4,6 +4,8 @@
 import sys
 from pathlib import Path
 
+import logging
+
 import pytest
 
 # Add project root to path
@@ -11,6 +13,8 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.inference.moe_router import ChessMoERouter
+from src.inference.inference import ChessGemmaInference
+from src.inference import inference as inference_module
 
 
 def test_route_query_deterministic_expert_selection():
@@ -61,3 +65,42 @@ def test_king_safety_improves_with_black_defenders():
 
     assert defended_score > exposed_score
     assert attacked_score < defended_score
+
+
+def test_moe_router_env_override(monkeypatch, tmp_path):
+    """MoE initialization should honor the router checkpoint override."""
+
+    checkpoints_root = tmp_path / "checkpoints"
+    (checkpoints_root / "lora_uci" / "checkpoint-1").mkdir(parents=True)
+    (checkpoints_root / "lora_tutor" / "checkpoint-1").mkdir(parents=True)
+
+    override_ckpt = tmp_path / "custom_router.pt"
+    override_ckpt.write_text("stub")
+
+    loaded_path = {}
+
+    def fake_load(self, path):
+        loaded_path["value"] = path
+
+    test_logger = logging.getLogger("test-moe-router")
+    monkeypatch.setattr(inference_module, "logger", test_logger, raising=False)
+    monkeypatch.setattr(ChessMoERouter, "load_router", fake_load, raising=True)
+    monkeypatch.setenv("CHESSGEMMA_MOE_ROUTER_CKPT", str(override_ckpt))
+
+    inference = ChessGemmaInference.__new__(ChessGemmaInference)
+    inference.project_root = tmp_path
+    inference.moe_enabled = True
+    inference.moe_router = None
+    inference.moe_manager = None
+    inference._expert_paths = {}
+    inference._moe_dispatch_depth = 0
+    inference.debug = False
+    inference.is_loaded = False
+    inference._prewarm_enabled = False
+    inference._prewarm_thread = None
+    inference.refresh_adapters = lambda: None
+    inference.set_active_adapter = lambda name: None
+
+    inference._initialize_moe_system()
+
+    assert loaded_path.get("value") == str(override_ckpt)


### PR DESCRIPTION
## Summary
- ensure the MoE router fallback search only runs when no override checkpoint is provided
- cover the router override path with a regression test to keep the environment behaviour stable

## Testing
- pytest tests/test_moe_router.py

------
https://chatgpt.com/codex/tasks/task_e_68f6b87aef748323a5af92bfc9c5d684